### PR TITLE
CASMINST-3617/CASMNET-967: Pull in new SLS version

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,17 @@ All notable changes to this project for v2.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2021-12-20
+### Changed
+- Updated SLS application version to 1.13.0:
+    - CASMINST-3617: Added PeerASN and MyASN to NetworkExtraProperties struct
+    - CASMNET-697: Added MetalLBPoolName to IPV4Subnet struct
+
+## [2.0.1] - 2021-11-18
+### Changed
+- Updated SLS application version to 1.12.0:
+    - CASMNET-692 - Added Bifurcated CAN default route toggle.
+
 ## [2.0.0] - 2021-11-16
 ### Changed
 - CASMHMS-5197: The cray-hms-sls Helm chart now pulls all images from artifactory.algol60.net instead of DTR.  

--- a/charts/v2.0/cray-hms-sls/Chart.yaml
+++ b/charts/v2.0/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.0.1
+version: 2.0.2
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.12.0
+appVersion: 1.13.0

--- a/charts/v2.0/cray-hms-sls/values.yaml
+++ b/charts/v2.0/cray-hms-sls/values.yaml
@@ -97,4 +97,4 @@ cray-service:
     uri: "/"
 
 global:
-  appVersion: 1.12.0
+  appVersion: 1.13.0

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -11,6 +11,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.11.0"
   "2.0.1": "1.12.0"
+  "2.0.2": "1.13.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Need to add the PeerASN, MyASN, and MetalLBPoolName to SLS in order to be able to properly upgrade customizations.yaml from 1.0 to 1.2.   For upgrades we are using SLS for the source of truth of the system configuration.   SLS has most of what is needed for MetalLB but it is missing the ASNs and the pool names.     This also cleans things up in CSI for generating customizations.yaml in a fresh install.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y (.version and CHANGELOG.md)

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Work required by CASMINST-3617 and CASMNET-967

### Testing

For testing See: https://github.com/Cray-HPE/hms-sls/pull/34

### Risks and Mitigations

ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No


