### PR TITLE
CASMHMS-5417 Chart updates for SLS GitHub Actions builds and Helm CT tests.

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,0 +1,10 @@
+# Changelog for v2.1
+
+All notable changes to this project for v2.1.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2022-05-19
+### Changed
+- CASMHMS-5417: Bump hms-sls version to 1.19.0 for GitHub Actions builds and Helm CT tests.

--- a/charts/v2.1/cray-hms-sls/Chart.lock
+++ b/charts/v2.1/cray-hms-sls/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: cray-service
+  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  version: 7.0.0
+digest: sha256:c04595364279402b13294b8666a8a97bfa79e4402b42ebbf0d2bcd4f52ec04ad
+generated: "2021-11-08T12:34:08.980177-06:00"

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: "cray-hms-sls"
+version: 2.1.0
+description: "Kubernetes resources for cray-hms-sls"
+home: https://github.com/Cray-HPE/hms-sls-charts
+sources:
+  - https://github.com/Cray-HPE/hms-sls
+maintainers:
+  - name: rsjostrand-hpe
+dependencies:
+  - name: cray-service
+    version: "~7.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+annotations:
+  artifacthub.io/license: MIT
+appVersion: 1.19.0

--- a/charts/v2.1/cray-hms-sls/README.md
+++ b/charts/v2.1/cray-hms-sls/README.md
@@ -1,0 +1,1 @@
+# cray-hms-sls

--- a/charts/v2.1/cray-hms-sls/templates/NOTES.txt
+++ b/charts/v2.1/cray-hms-sls/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Installation info for chart {{ include "cray-service.name" . }}:

--- a/charts/v2.1/cray-hms-sls/templates/_helpers.tpl
+++ b/charts/v2.1/cray-hms-sls/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Helper function to get the proper image tag
+*/}}
+{{- define "cray-sls.imageTag" -}}
+{{- default "latest" .Values.global.appVersion -}}
+{{- end -}}

--- a/charts/v2.1/cray-hms-sls/templates/hook-serviceaccout.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/hook-serviceaccout.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch", ""]
+  resources: ["jobs", "pods", "configmaps"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-hms-sls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-hms-sls
+subjects:
+  - kind: ServiceAccount
+    name: cray-hms-sls
+    namespace: services

--- a/charts/v2.1/cray-hms-sls/templates/jobs.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/jobs.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-nameserver-getter
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: nameserver-getter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}" 
+          command:
+          - /bin/sh
+          - -c
+          - set -exu;
+            sed -n '/nameserver/p' /host/resolv.conf > /tmp/nameserver;
+            echo "The following nameserver(s) was found from the hosts resolve.conf";
+            cat /tmp/nameserver;
+            kubectl -n services create configmap cray-sls-init-loader-nameserver --from-file=/tmp/nameserver
+            --dry-run -o yaml | kubectl apply -f -
+          volumeMounts:
+          - mountPath: /host/resolv.conf
+            name: resolv-dir
+            subPath: resolv.conf
+            readOnly: true
+      volumes:
+      # On the NCNs the file /etc/resolv.conf is a a symlink to /run/netconfig/resolv.conf
+      # This is true on both vshasta & baremetal, and k8s hostPath did not work with the symlink
+      - hostPath:
+          path: {{ .Values.namespaceGetter.resolvDir | quote }}
+        name: resolv-dir
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}" 
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting Jobs";
+            kubectl -n services delete job cray-sls-init-load;
+            while [ "`kubectl -n services get pods -l app=cray-sls-init-load -o jsonpath='{.items}'`" != "[]" ];
+            do
+              echo "Waiting for previous job to be removed entirely...";
+              sleep 1;
+            done;
+            echo "Old job deleted.";
+            exit 0
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: cray-sls-init-load
+  labels:
+    app: cray-sls-init-load
+spec:
+  template:
+    metadata:
+      labels:
+        app: cray-sls-init-load
+    spec:
+      restartPolicy:      OnFailure
+      serviceAccountName: "jobs-watcher"
+      initContainers:
+        - name: cray-sls-init
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-init"]
+          env:
+            - name: POSTGRES_HOST
+              value: "cray-sls-postgres"
+            - name: DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "username"
+            - name: DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "password"
+            - name: SCHEMA_VERSION
+              value: "{{ .Values.schemaVersion }}"
+          volumeMounts:
+            - mountPath: "/persistent_migrations"
+              name: schema
+      containers:
+        - name: cray-sls-loader
+          env:
+            - name: SLS_FILE_PATH
+              value: "/sls/sls_input_file.json"
+            - name: SLS_URL
+              value: "http://cray-sls"
+            - name: SLS_LOADER_FORCE_UPLOAD
+              value: "{{ .Values.loader.forceUpload }}"
+            - name: SLS_LOADER_CHECK_S3_MARKER
+              value: "{{ .Values.loader.checkS3Marker }}"
+            - name: SLS_LOADER_CHECK_SLS_CONTENTS
+              value: "{{ .Values.loader.checkSLSContents }}"
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: s3_endpoint
+            - name: S3_BUCKET
+              value: sls
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: access_key
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: secret_key
+            - name: MAX_PING_BUCKET_ATTEMPTS
+              value: "{{ .Values.loader.max_ping_bucket_attempts }}"            
+            - name: USE_S3_DNS_HACK
+              value: "{{ .Values.loader.use_s3_dns_hack }}"
+            - name: S3_DNS_LOOKUP_ATTEMPTS
+              value: "{{ .Values.loader.s3_dns_lookup_attempts }}"
+            - name: PIT_NAMESERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: cray-sls-init-loader-nameserver
+                  key: nameserver
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-loader"]
+      volumes:
+        - name: schema
+          persistentVolumeClaim:
+            claimName: cray-hms-sls-schema-pvc

--- a/charts/v2.1/cray-hms-sls/templates/schema-pvc.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/schema-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cray-hms-sls-schema-pvc
+spec:
+  accessModes:
+    - "{{ .Values.schemaAccessMode }}"
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "{{ .Values.schemaStorageClass }}"

--- a/charts/v2.1/cray-hms-sls/templates/tests/test-functional.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/tests/test-functional.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]

--- a/charts/v2.1/cray-hms-sls/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/tests/test-smoke.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh smoke -f smoke.json -u http://cray-sls"]

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -1,0 +1,105 @@
+---
+global:
+  appVersion: 1.19.0
+  testVersion: 1.19.0
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-sls-test
+    pullPolicy: IfNotPresent
+
+# TODO this should be moved to the database migration job, as it doens't need to be told as it should know as the schema version should be baked into the image.
+schemaVersion: "3"  # This needs to match the database schema version that the application requires
+schemaStorageClass: ceph-cephfs-external
+schemaAccessMode: ReadWriteMany
+
+namespaceGetter:
+  resolvDir: /etc/  # For CSM 1.1 and older use /run/netconfig/
+
+loader:
+  forceUpload: false
+  checkS3Marker: true
+  checkSLSContents: false
+  max_ping_bucket_attempts: 30
+  use_s3_dns_hack: true  # Should be false on vshasta, true on baremetal
+  s3_dns_lookup_attempts: 30
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-sls"
+  fullnameOverride: "cray-sls"
+  serviceAccountName: "jobs-watcher"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-sls
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-sls:
+      name: "cray-sls"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+        pullPolicy: IfNotPresent
+      ports:
+        - name: http
+          containerPort: 8376
+      env:
+        - name: DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: username
+        - name: DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: password
+        - name: SLS_MAX_DATABASE_CONNECTIONS
+          value: "25"
+      livenessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/readiness
+        initialDelaySeconds: 15
+        periodSeconds: 30
+  sqlCluster:
+    enabled: true
+    tls:
+      enabled: true
+    users:
+      slsuser: []
+    databases:
+      sls: slsuser
+    backup:
+      enabled: true
+      schedule: "10 23 * * *"  # Once per day at 11:10 pm
+  ingress:
+    enabled: true
+    prefix: "/apis/sls/"
+    uri: "/"

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -3,8 +3,9 @@
 chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.1.0": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
 
-# The application version must be compliant to semantic versioning. 
+# The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
 # This is the idealized world
 chartVersionToApplicationVersion:
@@ -12,20 +13,21 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.11.0"
   "2.0.1": "1.12.0"
   "2.0.2": "1.13.0"
+  "2.1.0": "1.19.0"
 
-# Test results for combinations of Chart, Application, and CSM versions.  
+# Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:
 - chartVersion: 2.0.0
   applicationVersion: 1.11.0
   csm: 1.2.0-alpha.16
-  environment: baremetal 
-  result: PASS 
+  environment: baremetal
+  result: PASS
   tester: rsjostrand-hpe
   date: 2021-11-17
 - chartVersion: 2.0.1-20211117222138+a343000b
   applicationVersion: 1.12.0
   csm: 1.2.0-alpha.16
-  environment: baremetal 
-  result: PASS 
+  environment: baremetal
+  result: PASS
   tester: rsjostrand-hpe
   date: 2021-11-17

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -31,3 +31,10 @@ chartValidationLog:
   result: PASS
   tester: rsjostrand-hpe
   date: 2021-11-17
+- chartVersion: 2.1.0-20220519212819+e1136a1
+  applicationVersion: 1.19.0
+  csm: 1.2.0-beta.115
+  environment: baremetal
+  result: PASS
+  tester: schooler-hpe
+  date: 2022-05-19


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

* Update SLS to build using GitHub Actions instead of Jenkins
* Pull images from algol60 instead of arti.dev.cray.com
* Update Alpine base image version
* Stop building CT test RPMs and instead package/execute them via Helm
* Add a runCT.sh script/workflow that stands up an instance of SLS, populates it, and executes the CT tests against it

### Issues and Related PRs

* Resolves CASMHMS-5417.

### Testing

This change was tested by executing the SLS unit tests and verifying that they continued to pass. The SLS CT tests were also run as part of the new GitHub Actions workflow and verified to pass. The new version of SLS was also installed on Mug using Helm and confirmed to succeed by executing the new CT test Helm job, as well as the former RPM version of the CT tests, and verified to pass.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low/moderate risk since this is a significant refactoring of how SLS builds and is tested, but the core functionality is unchanged.