### PR TITLE
CASMHMS-5575 Helm CT Test job configuration updates for no retries and istio sidecar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Cray / HPE
+Copyright (c) 2021-2022 Cray / HPE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2022-06-07
+### Added
+- Set CT test job backoffLimit to zero so retries aren't attempted on failures.
+- Set holdApplicationUntilProxyStarts pod annotation for istio sidecar.
+
 ## [2.1.0] - 2022-05-19
 ### Changed
 - CASMHMS-5417: Bump hms-sls version to 1.19.0 for GitHub Actions builds and Helm CT tests.

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.0
+version: 2.1.1
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:

--- a/charts/v2.1/cray-hms-sls/templates/tests/test-functional.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/tests/test-functional.yaml
@@ -12,9 +12,12 @@ metadata:
     app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
 
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
       labels:
         app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
         app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
@@ -30,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]
+          args: [ "entrypoint.sh functional -c /src/libs/tavern_global_config.yaml -p /src/app"]

--- a/charts/v2.1/cray-hms-sls/templates/tests/test-smoke.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/tests/test-smoke.yaml
@@ -12,9 +12,12 @@ metadata:
     app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
 
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
       labels:
         app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
         app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
@@ -30,4 +33,4 @@ spec:
           image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
           imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
           command: ["/bin/sh", "-c"]
-          args: [ "until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; entrypoint.sh smoke -f smoke.json -u http://cray-sls"]
+          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-sls"]

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -3,7 +3,7 @@
 chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
-  ">=2.1.0": "~1.3.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.1.0": "~1.3.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -14,6 +14,7 @@ chartVersionToApplicationVersion:
   "2.0.1": "1.12.0"
   "2.0.2": "1.13.0"
   "2.1.0": "1.19.0"
+  "2.1.1": "1.19.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Set CT test job backoffLimit to zero so retries aren't attempted on failures
- Set holdApplicationUntilProxyStarts pod annotation for istio sidecar to cleanup the "Waiting for Sidecar" code

### Issues and Related PRs

* Partially resolves CASMHMS-5575.

### Testing

See testing from: https://github.com/Cray-HPE/hms-bss-charts/pull/15

### Risks and Mitigations

Low risk, minor changes to new Helm CT test job configuration