### PR TITLE
CASMHMS-5458 Coordination for HMS CT Helm tests

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2022-06-23
+### Changed
+- Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination.
+
 ## [2.1.1] - 2022-06-07
 ### Added
 - Set CT test job backoffLimit to zero so retries aren't attempted on failures.

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.1
+version: 2.1.2
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.19.0
+appVersion: 1.20.0

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -16,7 +16,7 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-sls-test
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
 # TODO this should be moved to the database migration job, as it doens't need to be told as it should know as the schema version should be baked into the image.
 schemaVersion: "3"  # This needs to match the database schema version that the application requires

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -1,13 +1,7 @@
 ---
 global:
-  appVersion: 1.19.0
-  testVersion: 1.19.0
-
-kubectl:
-  image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
-    pullPolicy: IfNotPresent
+  appVersion: 1.20.0
+  testVersion: 1.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls
@@ -16,7 +10,13 @@ image:
 tests:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-sls-test
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
 
 # TODO this should be moved to the database migration job, as it doens't need to be told as it should know as the schema version should be baked into the image.
 schemaVersion: "3"  # This needs to match the database schema version that the application requires

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -15,6 +15,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.13.0"
   "2.1.0": "1.19.0"
   "2.1.1": "1.19.0"
+  "2.1.2": "1.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update CT tests to stable hms-test:3.1.0 image (upgrades pytest and tavern to work around python issue43798)
- Pull Alpine base image from correct location in algol60 artifactory
- CT test cleanup

### Issues and Related PRs

* Partially resolves CASMHMS-5458.

### Testing

This change was tested by deploying the updated version of the service and chart onto Mug, executing the Helm CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.