### PR TITLE
CASMHMS-5291: Bump SLS application version

### DIFF
--- a/.github/workflows/charts_lint_test_scan.yaml
+++ b/.github/workflows/charts_lint_test_scan.yaml
@@ -2,7 +2,7 @@ name: Lint, test, and scan Helm charts
 on:
   pull_request:
     branches:
-      - master
+      - main
       - release/**
   workflow_dispatch:
 jobs:

--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2022-07-11
+
+### Changed
+- CASMHMS-5291: Add Model field to the cabinet extra properties structure, and migrated SLS to the latest hms-xname and hms-base libraries.
+
 ## [2.1.2] - 2022-06-23
 ### Changed
 - Updated CT tests to hms-test:3.1.0 image as part of Helm test coordination.

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.2
+version: 2.1.3
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.20.0
+appVersion: 1.21.0

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 1.20.0
-  testVersion: 1.20.0
+  appVersion: 1.21.0
+  testVersion: 1.21.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -16,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.19.0"
   "2.1.1": "1.19.0"
   "2.1.2": "1.20.0"
+  "2.1.3": "1.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Add Model field to the cabinet extra properties structure, and migrated SLS to the latest hms-xname and hms-base libraries.

### Issues and Related PRs
* Resolves [CASMHMS-5291](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5291)

### Risks and Mitigations
Low risk
