### PR TITLE
Fix sls-init permissions issues

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2022-07-13
+
+### Fixed
+
+- CASMHMS-5475 - Fixed sls-init job permissions issues
+
 ## [2.1.3] - 2022-07-11
 
 ### Changed

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.3
+version: 2.1.4
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:

--- a/charts/v2.1/cray-hms-sls/templates/jobs.yaml
+++ b/charts/v2.1/cray-hms-sls/templates/jobs.yaml
@@ -88,6 +88,9 @@ spec:
         app: cray-sls-init-load
     spec:
       restartPolicy:      OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: "jobs-watcher"
       initContainers:
         - name: cray-sls-init

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "2.1.1": "1.19.0"
   "2.1.2": "1.20.0"
   "2.1.3": "1.21.0"
+  "2.1.4": "1.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

During upgrades sls-init would fail due to permissions issues on SLS's PVC. This adds an explicit security context to the sls-init job to prevent this issue.

### Issues and Related PRs

* Resolves [CASMHMS-5475](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5475)

### Testing

Tested on:

* Mercury

Was an Upgrade tested? Y
Was a Downgrade tested? Y

Upgrade/downgrade testing was sufficient for this modification.

### Risks and Mitigations

None.
