### PR TITLE
CASMINST-3788: Update SLS application version

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2022-07-27
+### Changed
+- Update SLS application version to 1.23.0:
+  - CASMINST-3788: Add SLS Migrator to deal with malformed data from older CSM releases on helm chart upgrades.
+
 ## [2.1.5] - 2022-07-19
 ### Changed
 - Updated SLS application version to 1.22.0:

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.5
+version: 2.1.6
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.22.0
+appVersion: 1.23.0

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 1.22.0
-  testVersion: 1.22.0
+  appVersion: 1.23.0
+  testVersion: 1.23.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -19,6 +19,7 @@ chartVersionToApplicationVersion:
   "2.1.3": "1.21.0"
   "2.1.4": "1.21.0"
   "2.1.5": "1.22.0"
+  "2.1.6": "1.23.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.
- Update SLS application version to 1.23.0:
  - CASMINST-3788: Add SLS Migrator to deal with malformed data from older CSM releases on helm chart upgrades.

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Resolves [CASMINST-3788](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3788)

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:
* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? Yes
Was an Upgrade tested?                 Y/N   If not, Why? Yes
Was a Downgrade tested?                Y/N   If not, Why? Yes
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

For testing see: https://github.com/Cray-HPE/hms-sls/pull/52

### Risks and Mitigations
Low risk
