### PR TITLE
Updated SLS application version to 1.27.0

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -5,6 +5,14 @@ All notable changes to this project for v2.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.7] - 2022-08-29
+### Changed
+- Update SLS application version to 1.27.0:
+  - CASMHMS-5696 - Disallow networks with an empty name.
+  - CASMHMS-4267 - Added validation to loadstate.
+  - CASMHMS-5691 - Added the slignshot11 network type.
+  - CASMINST-3902 - Expanded the SLS client to perform dumpstate and PUT to networks.
+
 ## [2.1.6] - 2022-07-27
 ### Changed
 - Update SLS application version to 1.23.0:

--- a/charts/v2.1/cray-hms-sls/Chart.yaml
+++ b/charts/v2.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 2.1.6
+version: 2.1.7
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -13,4 +13,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 1.23.0
+appVersion: 1.27.0

--- a/charts/v2.1/cray-hms-sls/values.yaml
+++ b/charts/v2.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 1.23.0
-  testVersion: 1.23.0
+  appVersion: 1.27.0
+  testVersion: 1.27.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "2.1.4": "1.21.0"
   "2.1.5": "1.22.0"
   "2.1.6": "1.23.0"
+  "2.1.7": "1.27.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Changes:
- CASMHMS-5696 - Disallow networks with an empty name.
- CASMHMS-4267 - Added validation to loadstate.
- CASMHMS-5691 - Added the slignshot11 network type.
- CASMINST-3902 - Expanded the SLS client to perform dumpstate and PUT to networks.