### PR TITLE
CASMHMS-5916: Support for caching and database interaction improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # Helm
 .packaged
+*.tgz
+Chart.lock
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -1,0 +1,11 @@
+# Changelog for v5.0
+
+All notable changes to this project for v5.1.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [5.1.0] - 2023-06-23
+### Changed
+- CASMHMS-5916: Add options to control whether caching is enabled or disabled. By default caching is disabled.  
+- Pull in newer SLS container image that supports caching, and database improvements.

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 5.0.0
+version: 5.1.0
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -16,4 +16,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 2.0.0
+appVersion: 2.2.0

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: "cray-hms-sls"
+version: 5.0.0
+description: "Kubernetes resources for cray-hms-sls"
+home: https://github.com/Cray-HPE/hms-sls-charts
+sources:
+  - https://github.com/Cray-HPE/hms-sls
+maintainers:
+  - name: rsjostrand-hpe
+dependencies:
+  - name: cray-service
+    version: "~10.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-postgresql
+    version: "~1.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+annotations:
+  artifacthub.io/license: MIT
+appVersion: 2.0.0

--- a/charts/v5.1/cray-hms-sls/README.md
+++ b/charts/v5.1/cray-hms-sls/README.md
@@ -1,0 +1,1 @@
+# cray-hms-sls

--- a/charts/v5.1/cray-hms-sls/templates/NOTES.txt
+++ b/charts/v5.1/cray-hms-sls/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Installation info for chart {{ include "cray-service.name" . }}:

--- a/charts/v5.1/cray-hms-sls/templates/_helpers.tpl
+++ b/charts/v5.1/cray-hms-sls/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Helper function to get the proper image tag
+*/}}
+{{- define "cray-sls.imageTag" -}}
+{{- default "latest" .Values.global.appVersion -}}
+{{- end -}}

--- a/charts/v5.1/cray-hms-sls/templates/configmap.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-sls-config
+  namespace: services
+data:
+  cache.enabled: "{{ .Values.configuration.cache.enabled }}"
+  cache.ttlSeconds: "{{ .Values.configuration.cache.ttlSeconds }}"
+  cache.capacity: "{{ .Values.configuration.cache.capacity }}"
+  database.maxConnections: "{{ .Values.configuration.database.maxConnections }}"

--- a/charts/v5.1/cray-hms-sls/templates/hook-serviceaccout.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/hook-serviceaccout.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch", ""]
+  resources: ["jobs", "pods", "configmaps"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-hms-sls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-hms-sls
+subjects:
+  - kind: ServiceAccount
+    name: cray-hms-sls
+    namespace: services

--- a/charts/v5.1/cray-hms-sls/templates/jobs.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/jobs.yaml
@@ -1,0 +1,167 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-nameserver-getter
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: nameserver-getter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -exu;
+            sed -n '/nameserver/p' /host/resolv.conf > /tmp/nameserver;
+            echo "The following nameserver(s) was found from the hosts resolve.conf";
+            cat /tmp/nameserver;
+            kubectl -n services create configmap cray-sls-init-loader-nameserver --from-file=/tmp/nameserver
+            --dry-run -o yaml | kubectl apply -f -
+          volumeMounts:
+          - mountPath: /host/resolv.conf
+            name: resolv-dir
+            subPath: resolv.conf
+            readOnly: true
+      volumes:
+      # On the NCNs the file /etc/resolv.conf is a a symlink to /run/netconfig/resolv.conf
+      # This is true on both vshasta & baremetal, and k8s hostPath did not work with the symlink
+      - hostPath:
+          path: {{ .Values.namespaceGetter.resolvDir | quote }}
+        name: resolv-dir
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting Jobs";
+            kubectl -n services delete job cray-sls-init-load;
+            while [ "`kubectl -n services get pods -l app=cray-sls-init-load -o jsonpath='{.items}'`" != "[]" ];
+            do
+              echo "Waiting for previous job to be removed entirely...";
+              sleep 1;
+            done;
+            echo "Old job deleted.";
+            exit 0
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: cray-sls-init-load
+  labels:
+    app: cray-sls-init-load
+spec:
+  template:
+    metadata:
+      labels:
+        app: cray-sls-init-load
+    spec:
+      restartPolicy:      OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: "jobs-watcher"
+      initContainers:
+        - name: cray-sls-init
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-init"]
+          env:
+            - name: POSTGRES_HOST
+              value: "cray-sls-postgres"
+            - name: DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "username"
+            - name: DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "password"
+            - name: SCHEMA_VERSION
+              value: "{{ .Values.schemaVersion }}"
+          volumeMounts:
+            - mountPath: "/persistent_migrations"
+              name: schema
+      containers:
+        - name: cray-sls-loader
+          env:
+            - name: SLS_FILE_PATH
+              value: "/sls/sls_input_file.json"
+            - name: SLS_URL
+              value: "http://cray-sls"
+            - name: SLS_LOADER_FORCE_UPLOAD
+              value: "{{ .Values.loader.forceUpload }}"
+            - name: SLS_LOADER_CHECK_S3_MARKER
+              value: "{{ .Values.loader.checkS3Marker }}"
+            - name: SLS_LOADER_CHECK_SLS_CONTENTS
+              value: "{{ .Values.loader.checkSLSContents }}"
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: s3_endpoint
+            - name: S3_BUCKET
+              value: sls
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: access_key
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: secret_key
+            - name: MAX_PING_BUCKET_ATTEMPTS
+              value: "{{ .Values.loader.max_ping_bucket_attempts }}"
+            - name: USE_S3_DNS_HACK
+              value: "{{ .Values.loader.use_s3_dns_hack }}"
+            - name: S3_DNS_LOOKUP_ATTEMPTS
+              value: "{{ .Values.loader.s3_dns_lookup_attempts }}"
+            - name: PIT_NAMESERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: cray-sls-init-loader-nameserver
+                  key: nameserver
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-loader"]
+      volumes:
+        - name: schema
+          persistentVolumeClaim:
+            claimName: cray-hms-sls-schema-pvc

--- a/charts/v5.1/cray-hms-sls/templates/schema-pvc.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/schema-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cray-hms-sls-schema-pvc
+spec:
+  accessModes:
+    - "{{ .Values.schemaAccessMode }}"
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "{{ .Values.schemaStorageClass }}"

--- a/charts/v5.1/cray-hms-sls/templates/tests/test-functional.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/tests/test-functional.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]
+

--- a/charts/v5.1/cray-hms-sls/templates/tests/test-smoke.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-sls"]

--- a/charts/v5.1/cray-hms-sls/values.yaml
+++ b/charts/v5.1/cray-hms-sls/values.yaml
@@ -1,0 +1,113 @@
+---
+global:
+  appVersion: 2.0.0
+  testVersion: 2.0.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-sls-hmth-test
+    pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
+
+# TODO this should be moved to the database migration job, as it doens't need to be told as it should know as the schema version should be baked into the image.
+schemaVersion: "3"  # This needs to match the database schema version that the application requires
+schemaStorageClass: ceph-cephfs-external
+schemaAccessMode: ReadWriteMany
+
+namespaceGetter:
+  resolvDir: /etc/  # For CSM 1.1 and older use /run/netconfig/
+
+loader:
+  forceUpload: false
+  checkS3Marker: true
+  checkSLSContents: false
+  max_ping_bucket_attempts: 30
+  use_s3_dns_hack: true  # Should be false on vshasta, true on baremetal
+  s3_dns_lookup_attempts: 30
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-sls"
+  fullnameOverride: "cray-sls"
+  serviceAccountName: "jobs-watcher"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-sls
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-sls:
+      name: "cray-sls"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+        pullPolicy: IfNotPresent
+      ports:
+        - name: http
+          containerPort: 8376
+      env:
+        - name: DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: username
+        - name: DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: password
+        - name: SLS_MAX_DATABASE_CONNECTIONS
+          value: "25"
+        - name: POSTGRES_HOST
+          value: cray-sls-postgres
+        - name: POSTGRES_PORT
+          value: "5432"
+      livenessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/readiness
+        initialDelaySeconds: 15
+        periodSeconds: 30
+  ingress:
+    enabled: true
+    prefix: "/apis/sls/"
+    uri: "/"
+
+cray-postgresql:
+  nameOverride: cray-sls
+  fullnameOverride: cray-sls
+  sqlCluster:
+    enabled: true
+    enableLogicalBackup: true
+    logicalBackupSchedule: "10 23 * * *"  # Once per day at 11:10 pm
+    instanceCount: 3
+    tls:
+      enabled: true
+    users:
+      slsuser: []
+    databases:
+      sls: slsuser

--- a/charts/v5.1/cray-hms-sls/values.yaml
+++ b/charts/v5.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.0.0
-  testVersion: 2.0.0
+  appVersion: 2.2.0
+  testVersion: 2.2.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls
@@ -33,6 +33,14 @@ loader:
   max_ping_bucket_attempts: 30
   use_s3_dns_hack: true  # Should be false on vshasta, true on baremetal
   s3_dns_lookup_attempts: 30
+
+configuration:
+  cache:
+    enabled: false
+    ttlSeconds: 15
+    capacity: 1000
+  database:
+    maxConnections: 25
 
 cray-service:
   type: "Deployment"
@@ -75,7 +83,25 @@ cray-service:
               name: slsuser.cray-sls-postgres.credentials
               key: password
         - name: SLS_MAX_DATABASE_CONNECTIONS
-          value: "25"
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: database.maxConnections
+        - name: CACHE_LAYER_ENABLE
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.enabled
+        - name: CACHE_TTL_SECONDS
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.ttlSeconds
+        - name: CACHE_CAPACITY
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.capacity
         - name: POSTGRES_HOST
           value: cray-sls-postgres
         - name: POSTGRES_PORT

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -7,6 +7,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": ">=1.3.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.6.0
   ">=4.0.0": ">=1.5.0"
   ">=5.0.0": ">=1.5.0"
+  ">=5.1.0": ">=1.5.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -30,6 +31,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "2.0.0"
   "4.0.0": "2.0.0"
   "5.0.0": "2.0.0"
+  "5.1.0": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.

- CASMHMS-5916: Add options to control whether caching is enabled or disabled. By default caching is disabled.  
- Pull in newer SLS container image that supports caching, and database improvements.
- Store SLS service configuration within a configmap, and have have the deployment reference it. This should allow for a better experience when overriding configuration that are passed as environment variables.  
   - Instead of needing to specify all environment variables, only the configuration options that need to be overriden can be specified. The cray-service base chart uses an array to specify environment variables, and there isn't a way to change a single element in the list so all have to be specified if the value `cray-service.containers.cray-sls.env` is specified.

This commit contains the delta between v5.0 and v5.1 charts https://github.com/Cray-HPE/hms-sls-charts/pull/27/commits/9c327b6c40473415de0d5de10abde30f1ae4ba24

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  No

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml, .version, CHANGELOG.md Yes

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: (C) Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y/N

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Resolves CASMHMS-5916

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:
* Ashton

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? Yes
Was an Upgrade tested?                 Y/N   If not, Why? Yes
Was a Downgrade tested?                Y/N   If not, Why? Yes
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? Yes

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Verified that SLS was still functional on Ashton after the upgrade to this version. Performed upgrade and downgrade testing on Ashton. Ran the HMS tavern tests to verify SLS was functional after the upgrade:
```
ncn-m002:~ # /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t sls
Log file for run is: /opt/cray/tests/hms_ct_test-20230623T161922.log
Running sls tests...
DONE.
SUCCESS: Service test passed: sls
```

Specified overrides to enable caching and change the number of database connections with the following manifest:
```
apiVersion: manifests/v1beta1
metadata:
  name: sls
spec:
  charts:
  - name: cray-hms-sls
    namespace: services
    version: 5.1.0-20230623154105+9a10b8e
    values:
      configuration:
        cache:
          enabled: true
        database:
          maxConnections: 24
      # Everything below is to make sure the right container image is used
      global:
        appVersion: 2.2.0-20230623152716.cd85145
        testVersion: 2.2.0-20230623152715.cd85145
      image:
        repository: artifactory.algol60.net/csm-docker/unstable/cray-sls
      tests:
        image:
          repository: artifactory.algol60.net/csm-docker/unstable/cray-sls-hmth-test
      cray-service:
        containers:
          cray-sls:
            image:
              repository: artifactory.algol60.net/csm-docker/unstable/cray-sls
```
I verified that the SLS was healthy with the HMS tavern tests:
```
ncn-m002:~ # /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t sls
Log file for run is: /opt/cray/tests/hms_ct_test-20230623T163306.log
Running sls tests...
DONE.
SUCCESS: Service test passed: sls
``` 

I rolled back the SLS helm chart to the orginal version, and verified that SLS was still healthy:
```
ncn-m002:~ # /opt/cray/csm/scripts/hms_verification/run_hms_ct_tests.sh -t sls
Log file for run is: /opt/cray/tests/hms_ct_test-20230623T164339.log
Running sls tests...
DONE.
SUCCESS: Service test passed: sls
```

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh)
ARE THERE KNOWN ISSUES WITH THESE CHANGES?
ANY OTHER SPECIAL CONSIDERATIONS?

INCLUDE THE FOLLOWING ITEMS THAT APPLY. LIST ADDITIONAL ITEMS AND PROVIDE MORE DETAILED INFORMATION AS APPROPRIATE.

Requires:

* Additional testing on bare-metal
* Compute nodes
* 3rd party software
* Broader integration testing
* Fresh install
* Platform upgrade
