### PR TITLE
Base charts update for k8s

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -4,8 +4,3 @@ jobs:
   k8s_api_checker:
     uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v2
     secrets: inherit
-    with:
-      # ignore-errors can be removed once the deprecated APIs are updated.
-      # Setting this to true causes the workflow to always complete as a success
-      # however the reports are still generated.
-      ignore-errors: true

--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v5.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2023-06-26
+### Changed
+- Updated the cray-service chart to 10.0.2
+
 ## [5.1.0] - 2023-06-23
 ### Changed
 - CASMHMS-5916: Add options to control whether caching is enabled or disabled. By default caching is disabled.  

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -9,10 +9,10 @@ maintainers:
   - name: rsjostrand-hpe
 dependencies:
   - name: cray-service
-    version: "~10.0.2"
+    version: "~10.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0.1"
+    version: "~1.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 5.1.0
+version: 5.1.1
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -9,7 +9,7 @@ maintainers:
   - name: rsjostrand-hpe
 dependencies:
   - name: cray-service
-    version: "~10.0"
+    version: "~10.0.2"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
     version: "~1.0"

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     version: "~10.0.2"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0"
+    version: "~1.0.1"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -7,7 +7,7 @@ chartVersionToCSMVersion:
   ">=3.0.0": ">=1.3.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.6.0
   ">=4.0.0": ">=1.5.0"
   ">=5.0.0": ">=1.5.0"
-  ">=5.1.0": ">=1.5.0"
+  ">=5.1.0": ">=1.5.0" # contains features specific to k8s 1.22 or later
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "4.0.0": "2.0.0"
   "5.0.0": "2.0.0"
   "5.1.0": "2.2.0"
+  "5.1.1": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

For the k8s 1.22 upgrade, this PR makes the following changes
* rebuilds to pick up base-charts:  cray-service 10.0.2, and cray-postgresql 1.0.1
* It documents which version is for k8s 1.22 or later
* Configures the deprecated k8s api checker to fail when there are deprecated APIs

### Issues and Related PRs

* Resolves [CASM-5880](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5880)

### Testing

Tested on:

* No additional testing beyond the automated tests


Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? N
Was an Upgrade tested?                 Y/N   If not, Why? N
Was a Downgrade tested?                Y/N   If not, Why? N


### Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable