### PR TITLE
Created version 5.1.2 to pick up postgres chart 1.0.4

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,11 @@ All notable changes to this project for v5.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2023-11-30
+### Changed
+- Removed support for VirtualNode by changing the app version to 2.2.0
+- Rebuild to pickup 1.0.4 postgres chart
+
 ## [5.1.3] - 2023-09-25
 ### Changed
 - Updated the ct tests for VirtualNode

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 5.1.3
+version: 5.1.4
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -16,4 +16,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 2.4.0
+appVersion: 2.2.0

--- a/charts/v5.1/cray-hms-sls/values.yaml
+++ b/charts/v5.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.4.0
-  testVersion: 2.4.0
+  appVersion: 2.2.0
+  testVersion: 2.2.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -34,7 +34,8 @@ chartVersionToApplicationVersion:
   "5.1.0": "2.2.0"
   "5.1.1": "2.2.0"
   "5.1.2": "2.3.0"
-  "5.1.3": "2.4.0"
+  "5.1.3": "2.4.0" # 2.4.0 and 2.3.0 app version contain the virtual node support
+  "5.1.4": "2.2.0" # rebuild to pick up 1.0.4 postgres chart for 1.5
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION

### Summary and Scope

Rebuild to pick up 1.0.4 postgres chart.
This also goes back to an earlier app version, to avoid the VirtualNode changes in sls

CASMHMS-6110

### Issues and Related PRs

* ResolvesCASMHMS-6110

### Testing

Tested on:

* only auto tests in github

### Risks and Mitigations

