### PR TITLE
Set the time to live on cray-sls-init-load in 5.1.5

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v5.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.5] - 2023-04-12
+### Changed
+- Added time to live (TTL) setting to the init job
+
 ## [5.1.4] - 2023-11-30
 ### Changed
 - Removed support for VirtualNode by changing the app version to 2.2.0

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 5.1.4
+version: 5.1.5
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:

--- a/charts/v5.1/cray-hms-sls/templates/jobs.yaml
+++ b/charts/v5.1/cray-hms-sls/templates/jobs.yaml
@@ -82,6 +82,7 @@ metadata:
   labels:
     app: cray-sls-init-load
 spec:
+  ttlSecondsAfterFinished: {{ .Values.slsInitJobTTL }}
   template:
     metadata:
       labels:

--- a/charts/v5.1/cray-hms-sls/values.yaml
+++ b/charts/v5.1/cray-hms-sls/values.yaml
@@ -42,6 +42,8 @@ configuration:
   database:
     maxConnections: 25
 
+slsInitJobTTL: 2147483647
+
 cray-service:
   type: "Deployment"
   nameOverride: "cray-sls"

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -36,6 +36,7 @@ chartVersionToApplicationVersion:
   "5.1.2": "2.3.0"
   "5.1.3": "2.4.0" # 2.4.0 and 2.3.0 app version contain the virtual node support
   "5.1.4": "2.2.0" # rebuild to pick up 1.0.4 postgres chart for 1.5
+  "5.1.5": "2.2.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Set the time to live to a very large number so that the init job will not be removed.

### Issues and Related PRs

* Resolves CASMTRIAGE-6876

### Testing

Tested on:

* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y
Was a Downgrade tested?                Y/N   If not, Why? Y

### Risks and Mitigations
