### PR TITLE
Updated app version to support VirtualNodes

### DIFF
--- a/changelog/v5.1.md
+++ b/changelog/v5.1.md
@@ -5,6 +5,10 @@ All notable changes to this project for v5.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.7] - 2024-08-21
+### Changed
+- Updated to the app version that supports VirtualNodes
+
 ## [5.1.6] - 2024-07-11
 ### Changed
 - Updated cray-service chart to 10.0.6

--- a/charts/v5.1/cray-hms-sls/Chart.yaml
+++ b/charts/v5.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 5.1.6
+version: 5.1.7
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -16,4 +16,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 2.2.0
+appVersion: 2.4.0

--- a/charts/v5.1/cray-hms-sls/values.yaml
+++ b/charts/v5.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.2.0
-  testVersion: 2.2.0
+  appVersion: 2.4.0
+  testVersion: 2.4.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -38,6 +38,7 @@ chartVersionToApplicationVersion:
   "5.1.4": "2.2.0" # rebuild to pick up 1.0.4 postgres chart for 1.5
   "5.1.5": "2.2.0"
   "5.1.6": "2.2.0"
+  "5.1.7": "2.4.0" # contains virtual node support
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

This adds support for VirtualNodes. CSM does not need VirtualNode support, however, it is being left in SLS because it would require too much work to remove from HSM.

### Issues and Related PRs

* Resolves [CASMHMS-6237](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6237)

### Testing

Tested on:

* surtur

### Risks and Mitigations

