### PR TITLE
Updated dependences for kuberentes 1.24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Chart.lock
 # VSCode
 .vscode
 
+# vim
+*.swp
+
 # Prevent certificates from getting checked in
 *.ca
 *.cer

--- a/changelog/v6.0.md
+++ b/changelog/v6.0.md
@@ -1,0 +1,10 @@
+# Changelog for v6.0
+
+All notable changes to this project for v6.0.X will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [6.0.0] - 2024-08-28
+### Changed
+- Changed for the upgrade to kubernetes 1.24

--- a/charts/v6.0/cray-hms-sls/Chart.yaml
+++ b/charts/v6.0/cray-hms-sls/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: "cray-hms-sls"
+version: 6.0.0
+description: "Kubernetes resources for cray-hms-sls"
+home: https://github.com/Cray-HPE/hms-sls-charts
+sources:
+  - https://github.com/Cray-HPE/hms-sls
+maintainers:
+  - name: rsjostrand-hpe
+dependencies:
+  - name: cray-service
+    version: "~11.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-postgresql
+    version: "~1.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+annotations:
+  artifacthub.io/license: MIT
+appVersion: 2.5.0

--- a/charts/v6.0/cray-hms-sls/README.md
+++ b/charts/v6.0/cray-hms-sls/README.md
@@ -1,0 +1,1 @@
+# cray-hms-sls

--- a/charts/v6.0/cray-hms-sls/templates/NOTES.txt
+++ b/charts/v6.0/cray-hms-sls/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Installation info for chart {{ include "cray-service.name" . }}:

--- a/charts/v6.0/cray-hms-sls/templates/_helpers.tpl
+++ b/charts/v6.0/cray-hms-sls/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Helper function to get the proper image tag
+*/}}
+{{- define "cray-sls.imageTag" -}}
+{{- default "latest" .Values.global.appVersion -}}
+{{- end -}}

--- a/charts/v6.0/cray-hms-sls/templates/configmap.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-sls-config
+  namespace: services
+data:
+  cache.enabled: "{{ .Values.configuration.cache.enabled }}"
+  cache.ttlSeconds: "{{ .Values.configuration.cache.ttlSeconds }}"
+  cache.capacity: "{{ .Values.configuration.cache.capacity }}"
+  database.maxConnections: "{{ .Values.configuration.database.maxConnections }}"

--- a/charts/v6.0/cray-hms-sls/templates/hook-serviceaccout.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/hook-serviceaccout.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-hms-sls
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch", ""]
+  resources: ["jobs", "pods", "configmaps"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-hms-sls
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-hms-sls
+subjects:
+  - kind: ServiceAccount
+    name: cray-hms-sls
+    namespace: services

--- a/charts/v6.0/cray-hms-sls/templates/jobs.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/jobs.yaml
@@ -1,0 +1,168 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-nameserver-getter
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: nameserver-getter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -exu;
+            sed -n '/nameserver/p' /host/resolv.conf > /tmp/nameserver;
+            echo "The following nameserver(s) was found from the hosts resolve.conf";
+            cat /tmp/nameserver;
+            kubectl -n services create configmap cray-sls-init-loader-nameserver --from-file=/tmp/nameserver
+            --dry-run -o yaml | kubectl apply -f -
+          volumeMounts:
+          - mountPath: /host/resolv.conf
+            name: resolv-dir
+            subPath: resolv.conf
+            readOnly: true
+      volumes:
+      # On the NCNs the file /etc/resolv.conf is a a symlink to /run/netconfig/resolv.conf
+      # This is true on both vshasta & baremetal, and k8s hostPath did not work with the symlink
+      - hostPath:
+          path: {{ .Values.namespaceGetter.resolvDir | quote }}
+        name: resolv-dir
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-sls-init-load-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: “false”
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-hms-sls"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo "Deleting Jobs";
+            kubectl -n services delete job cray-sls-init-load;
+            while [ "`kubectl -n services get pods -l app=cray-sls-init-load -o jsonpath='{.items}'`" != "[]" ];
+            do
+              echo "Waiting for previous job to be removed entirely...";
+              sleep 1;
+            done;
+            echo "Old job deleted.";
+            exit 0
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: cray-sls-init-load
+  labels:
+    app: cray-sls-init-load
+spec:
+  ttlSecondsAfterFinished: {{ .Values.slsInitJobTTL }}
+  template:
+    metadata:
+      labels:
+        app: cray-sls-init-load
+    spec:
+      restartPolicy:      OnFailure
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: "jobs-watcher"
+      initContainers:
+        - name: cray-sls-init
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-init"]
+          env:
+            - name: POSTGRES_HOST
+              value: "cray-sls-postgres"
+            - name: DBUSER
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "username"
+            - name: DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: "slsuser.cray-sls-postgres.credentials"
+                  key:  "password"
+            - name: SCHEMA_VERSION
+              value: "{{ .Values.schemaVersion }}"
+          volumeMounts:
+            - mountPath: "/persistent_migrations"
+              name: schema
+      containers:
+        - name: cray-sls-loader
+          env:
+            - name: SLS_FILE_PATH
+              value: "/sls/sls_input_file.json"
+            - name: SLS_URL
+              value: "http://cray-sls"
+            - name: SLS_LOADER_FORCE_UPLOAD
+              value: "{{ .Values.loader.forceUpload }}"
+            - name: SLS_LOADER_CHECK_S3_MARKER
+              value: "{{ .Values.loader.checkS3Marker }}"
+            - name: SLS_LOADER_CHECK_SLS_CONTENTS
+              value: "{{ .Values.loader.checkSLSContents }}"
+            - name: S3_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: s3_endpoint
+            - name: S3_BUCKET
+              value: sls
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: access_key
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: sls-s3-credentials
+                  key: secret_key
+            - name: MAX_PING_BUCKET_ATTEMPTS
+              value: "{{ .Values.loader.max_ping_bucket_attempts }}"
+            - name: USE_S3_DNS_HACK
+              value: "{{ .Values.loader.use_s3_dns_hack }}"
+            - name: S3_DNS_LOOKUP_ATTEMPTS
+              value: "{{ .Values.loader.s3_dns_lookup_attempts }}"
+            - name: PIT_NAMESERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: cray-sls-init-loader-nameserver
+                  key: nameserver
+          image: "{{ .Values.image.repository }}:{{ include "cray-sls.imageTag" . }}"
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          command: ["/entrypoint.sh"]
+          args: ["sls-loader"]
+      volumes:
+        - name: schema
+          persistentVolumeClaim:
+            claimName: cray-hms-sls-schema-pvc

--- a/charts/v6.0/cray-hms-sls/templates/schema-pvc.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/schema-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cray-hms-sls-schema-pvc
+spec:
+  accessModes:
+    - "{{ .Values.schemaAccessMode }}"
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "{{ .Values.schemaStorageClass }}"

--- a/charts/v6.0/cray-hms-sls/templates/tests/test-functional.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/tests/test-functional.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-functional"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "1" #run this after smoke!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-functional"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-functional"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-functional"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "functional"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh tavern -c /src/libs/tavern_global_config.yaml -p /src/app/api/1-non-disruptive"]
+

--- a/charts/v6.0/cray-hms-sls/templates/tests/test-smoke.yaml
+++ b/charts/v6.0/cray-hms-sls/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: ["entrypoint.sh smoke -f smoke.json -u http://cray-sls"]

--- a/charts/v6.0/cray-hms-sls/values.yaml
+++ b/charts/v6.0/cray-hms-sls/values.yaml
@@ -1,0 +1,141 @@
+---
+global:
+  appVersion: 2.5.0
+  testVersion: 2.5.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-sls-hmth-test
+    pullPolicy: IfNotPresent
+
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.24.17
+    pullPolicy: IfNotPresent
+
+# TODO this should be moved to the database migration job, as it doens't need to be told as it should know as the schema version should be baked into the image.
+schemaVersion: "3"  # This needs to match the database schema version that the application requires
+schemaStorageClass: ceph-cephfs-external
+schemaAccessMode: ReadWriteMany
+
+namespaceGetter:
+  resolvDir: /etc/  # For CSM 1.1 and older use /run/netconfig/
+
+loader:
+  forceUpload: false
+  checkS3Marker: true
+  checkSLSContents: false
+  max_ping_bucket_attempts: 30
+  use_s3_dns_hack: true  # Should be false on vshasta, true on baremetal
+  s3_dns_lookup_attempts: 30
+
+configuration:
+  cache:
+    enabled: false
+    ttlSeconds: 15
+    capacity: 1000
+  database:
+    maxConnections: 25
+
+slsInitJobTTL: 2147483647
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-sls"
+  fullnameOverride: "cray-sls"
+  serviceAccountName: "jobs-watcher"
+  replicaCount: 3
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - cray-sls
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 50%
+    type: RollingUpdate
+  containers:
+    cray-sls:
+      name: "cray-sls"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-sls
+        pullPolicy: IfNotPresent
+      ports:
+        - name: http
+          containerPort: 8376
+      env:
+        - name: DBUSER
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: username
+        - name: DBPASS
+          valueFrom:
+            secretKeyRef:
+              name: slsuser.cray-sls-postgres.credentials
+              key: password
+        - name: SLS_MAX_DATABASE_CONNECTIONS
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: database.maxConnections
+        - name: CACHE_LAYER_ENABLE
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.enabled
+        - name: CACHE_TTL_SECONDS
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.ttlSeconds
+        - name: CACHE_CAPACITY
+          valueFrom:
+            configMapKeyRef:
+              name: cray-sls-config
+              key: cache.capacity
+        - name: POSTGRES_HOST
+          value: cray-sls-postgres
+        - name: POSTGRES_PORT
+          value: "5432"
+      livenessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/liveness
+        initialDelaySeconds: 10
+        periodSeconds: 30
+      readinessProbe:
+        httpGet:
+          port: 8376
+          path: /v1/readiness
+        initialDelaySeconds: 15
+        periodSeconds: 30
+  ingress:
+    enabled: true
+    prefix: "/apis/sls/"
+    uri: "/"
+
+cray-postgresql:
+  nameOverride: cray-sls
+  fullnameOverride: cray-sls
+  sqlCluster:
+    enabled: true
+    enableLogicalBackup: true
+    logicalBackupSchedule: "10 23 * * *"  # Once per day at 11:10 pm
+    instanceCount: 3
+    tls:
+      enabled: true
+    users:
+      slsuser: []
+    databases:
+      sls: slsuser

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -1,13 +1,20 @@
 ---
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
+  # Summary:
+  #   Chart Version: 2.0.0 <= x.y.z,         CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  #   Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.5.0
+  #   Chart Version: 4.0.0 <= x.y.z < 6.0.0, CSM Version: 1.5.0 <= x.y.z < 1.6.0
+  #   Chart Version: 6.0.0 <= x.y.z,         CSM Version: 1.6.0 <= x.y.z
+  #
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=2.1.0": "~1.3.0"
-  ">=3.0.0": ">=1.3.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.6.0
+  ">=3.0.0": ">=1.3.0" # Chart Version: 3.0.0 <= x.y.z < 4.0.0, CSM Version: 1.3.0 <= x.y.z < 1.5.0
   ">=4.0.0": ">=1.5.0"
   ">=5.0.0": ">=1.5.0"
-  ">=5.1.0": ">=1.5.0" # contains features specific to k8s 1.22 or later
+  ">=5.1.0": ">=1.5.0" # 5.1.0 contains features specific to k8s 1.22 or later
+  ">=6.0.0": ">=1.6.0" # 6.0.0 contains features specific to k8s 1.24 or later
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -38,7 +45,8 @@ chartVersionToApplicationVersion:
   "5.1.4": "2.2.0" # rebuild to pick up 1.0.4 postgres chart for 1.5
   "5.1.5": "2.2.0"
   "5.1.6": "2.2.0"
-  "5.1.7": "2.4.0" # contains virtual node support
+  "5.1.7": "2.4.0" # 2.4.0 contains virtual node support
+  "6.0.0": "2.5.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

In CSM 1.6 kubernetes is being updated to 1.24
- Updated the cray-service chart to 11.0
- Updated docker-kubectl to 1.24.17

Also updated app version to 2.5.0 which adds support in the tests for IPv6 CIDR addresses.

Here is the diff between v5.1 and v6.0
```
diff -r charts/v5.1/cray-hms-sls/Chart.yaml charts/v6.0/cray-hms-sls/Chart.yaml
3c3
< version: 5.1.7
---
> version: 6.0.0
12c12
<     version: "~10.0"
---
>     version: "~11.0"
19c19
< appVersion: 2.4.0
---
> appVersion: 2.5.0
diff -r charts/v5.1/cray-hms-sls/values.yaml charts/v6.0/cray-hms-sls/values.yaml
3,4c3,4
<   appVersion: 2.4.0
<   testVersion: 2.4.0
---
>   appVersion: 2.5.0
>   testVersion: 2.5.0
18c18
<     tag: 1.19.15
---
>     tag: 1.24.17

```

### Issues and Related PRs

* Resolves [CASMHMS-6262](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6262)
* Resolves [CASMHMS-6260](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6260)

### Testing

Tested on:

* fanta
* dev system

### Risks and Mitigations

