### PR TITLE
CASMHMS-6324: Added support for ppprof builds

### DIFF
--- a/changelog/v6.0.md
+++ b/changelog/v6.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v6.0.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.2] - 2025-01-08
+
+### Added
+
+- Added support for ppprof builds
+
 ## [6.0.1] - 2024-12-09
 ### Changed
 - Updated go to 1.23

--- a/charts/v6.0/cray-hms-sls/Chart.yaml
+++ b/charts/v6.0/cray-hms-sls/Chart.yaml
@@ -14,6 +14,9 @@ dependencies:
   - name: cray-postgresql
     version: "~1.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+appVersion: 2.7.0  # update pprof image version below as well
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-sls-pprof
+      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.7.0
   artifacthub.io/license: MIT
-appVersion: 2.7.0

--- a/charts/v6.0/cray-hms-sls/Chart.yaml
+++ b/charts/v6.0/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.0.1
+version: 6.0.2
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -16,4 +16,4 @@ dependencies:
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 annotations:
   artifacthub.io/license: MIT
-appVersion: 2.6.0
+appVersion: 2.7.0

--- a/charts/v6.0/cray-hms-sls/values.yaml
+++ b/charts/v6.0/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.6.0
-  testVersion: 2.6.0
+  appVersion: 2.7.0
+  testVersion: 2.7.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -48,6 +48,7 @@ chartVersionToApplicationVersion:
   "5.1.7": "2.4.0" # 2.4.0 contains virtual node support
   "6.0.0": "2.5.0"
   "6.0.1": "2.6.0"
+  "6.0.2": "2.7.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image.  Profiling adds runtime overhead so the pprof enabled image is not used by default.  It is meant to be a debug tool.  In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name.  For unstable developer builds, be sure to change the built timestamp as well.

Adopted app version 2.7.0 for CSM 1.6.1 (helm chart 6.0.2)

## Issues and Related PRs

* Resolves [CASMHMS-6324](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6324)

## Testing

Tested on:

  * `mug`

Test description:

- Deployed service with pprof enabled - confirmed pprof functionality
- Deployed services with pprof disabled - confirmed pprof support not built into binary
- Functional tests (if they exist) was successfully ran with and without pprof enabled

Test Checklist:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable