### PR TITLE
CASMHMS-6399: Scaling and resource usage improvements

### DIFF
--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2025-05-02
+
+## Update
+
+- Updated module and image dependencies to latest versions
+- Update version of Go to v1.24
+- Explicitly drain and close all http request and response bodies
+- Internal tracking ticket: CASMHMS-6399
+
 ## [6.1.0] - 2025-02-18
 
 ### Security

--- a/charts/v6.1/cray-hms-sls/Chart.yaml
+++ b/charts/v6.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.1.0
+version: 6.1.1
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -14,9 +14,9 @@ dependencies:
   - name: cray-postgresql
     version: "~1.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-appVersion: 2.8.0  # update pprof image version below as well
+appVersion: 2.9.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-sls-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.8.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.9.0
   artifacthub.io/license: MIT

--- a/charts/v6.1/cray-hms-sls/values.yaml
+++ b/charts/v6.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.8.0
-  testVersion: 2.8.0
+  appVersion: 2.9.0
+  testVersion: 2.9.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -52,6 +52,7 @@ chartVersionToApplicationVersion:
   "6.0.1": "2.6.0"
   "6.0.2": "2.7.0"
   "6.1.0": "2.8.0"
+  "6.1.1": "2.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the hms-base module.

Made calls to explicitly drain and close all http request and response bodies.  There were some potential edge cases where memory leaks might have occurred.

Additionally upgraded Go from v1.23 to v1.24.

Adopted app version 2.9.0 for CSM 1.7.0 (helm chart 6.1.1).

### Issues and Related PRs

* Resolves [CASMHMS-6399](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6399)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched log files to ensure nothing obvious was wrong.  Ran the standard smoke and functional tests which all passed.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable