### PR TITLE
CASMHMS-6516: Bump postgresql and cray-service to latest versions

### DIFF
--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,11 +5,12 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.1.2] - 2025-05-13
+## [6.1.2] - 2025-05-14
 
 ### Updated
 
 - Updated cray-postgresql and cray-service dependencies to the latest versions
+- Internal tracking ticket: CASMHMS-6516
 
 ## [6.1.1] - 2025-05-02
 

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.2] - 2025-05-13
+
+### Updated
+
+- Updated cray-postgresql and cray-service dependencies to the latest versions
+
 ## [6.1.1] - 2025-05-02
 
 ## Update

--- a/charts/v6.1/cray-hms-sls/Chart.yaml
+++ b/charts/v6.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.1.1
+version: 6.1.2
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -9,10 +9,10 @@ maintainers:
   - name: rsjostrand-hpe
 dependencies:
   - name: cray-service
-    version: "~11.0"
+    version: "~12.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
   - name: cray-postgresql
-    version: "~1.0"
+    version: "~2.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 appVersion: 2.9.0  # update pprof image version below as well
 annotations:

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -53,6 +53,7 @@ chartVersionToApplicationVersion:
   "6.0.2": "2.7.0"
   "6.1.0": "2.8.0"
   "6.1.1": "2.9.0"
+  "6.1.2": "2.9.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated cray-postgresql and cray-service dependencies to the latest versions

New helm chart version is 6.1.2 (no app version change)

### Issues and Related PRs

* Resolves [CASMHMS-6516](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6516)

### Testing

Tested on:

* `beau` (vshasta)

Test description:

- Helm upgrade of the new chart
   - Had to do a 'rollout restart' to restart the pods since the container image didn't change
- Ran HMS CT tests
- Verified wait-for-postgres pod ran and functioned correctly
- Helm rollback to the prior version of the service

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable