### PR TITLE
Added changes to the docs and tests to support IPv6 fields

### DIFF
--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,6 +5,12 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.3] - 2025-06-10
+
+### Updated
+
+- Updated the app image to a version that supports the IPv6 fields: CIDR6, Gateway6, and IPAddress6
+
 ## [6.1.2] - 2025-05-14
 
 ### Updated

--- a/charts/v6.1/cray-hms-sls/Chart.yaml
+++ b/charts/v6.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.1.2
+version: 6.1.3
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -14,9 +14,9 @@ dependencies:
   - name: cray-postgresql
     version: "~2.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-appVersion: 2.9.0  # update pprof image version below as well
+appVersion: 2.10.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-sls-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.9.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.10.0
   artifacthub.io/license: MIT

--- a/charts/v6.1/cray-hms-sls/values.yaml
+++ b/charts/v6.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.9.0
-  testVersion: 2.9.0
+  appVersion: 2.10.0
+  testVersion: 2.10.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -54,6 +54,7 @@ chartVersionToApplicationVersion:
   "6.1.0": "2.8.0"
   "6.1.1": "2.9.0"
   "6.1.2": "2.9.0"
+  "6.1.3": "2.10.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
The only changes to support IPv6 were to the tests to allow the fields CIDR6, Gateway, and IPAddress6.

CASMHMS-6555

### Summary and Scope

Added changes to the docs and tests to support IPv6 fields

Changed tests to allow the fields: CIDR6, Gateway6, and IPAddress6.
Added the new fields to the API docs

### Issues and Related PRs

* Resolves CASMHMS-6555

### Testing

Tested on:

* tyr
* mug
* dev system

### Risks and Mitigations
