### PR TITLE
CASMNET-2310: IPv6 support in SLS subnets

### DIFF
--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.1.4] - 2025-09-22
+## [6.1.4] - 2025-09-23
 
 ### Added
 

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.4] - 2025-09-22
+
+### Added
+
+- IPv6 support in SLS subnets
+- Internal tracking ticket: CASMNET-2310
+
 ## [6.1.3] - 2025-06-10
 
 ### Updated

--- a/charts/v6.1/cray-hms-sls/Chart.yaml
+++ b/charts/v6.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.1.3
+version: 6.1.4
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -14,9 +14,9 @@ dependencies:
   - name: cray-postgresql
     version: "~2.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-appVersion: 2.10.0  # update pprof image version below as well
+appVersion: 2.11.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-sls-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.10.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.11.0
   artifacthub.io/license: MIT

--- a/charts/v6.1/cray-hms-sls/values.yaml
+++ b/charts/v6.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.10.0
-  testVersion: 2.10.0
+  appVersion: 2.11.0
+  testVersion: 2.11.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -55,6 +55,7 @@ chartVersionToApplicationVersion:
   "6.1.1": "2.9.0"
   "6.1.2": "2.9.0"
   "6.1.3": "2.10.0"
+  "6.1.4": "2.11.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Thic change provides critical support for IPv6.

Adopted app version 2.11.0 for CSM 1.7.x (helm chart 6.1.4)

### Issues and Related PRs

* Resolves [CASMNET-2310](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2310)

### Testing

This is changing code that has been tested in downstream projects, such as cray-site-init, on live systems (redbull and surtur).

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable