### PR TITLE
CASMHMS-6602: Update SLS Dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v3
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.5] - 2025-09-26
+
+### Security
+
+- Description of any changes made to the application (and helm chart)
+- Internal tracking ticket: CASMHMS-6599
+
 ## [6.1.4] - 2025-09-23
 
 ### Added

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Description of any changes made to the application (and helm chart)
+- Updated Alpine base image to pick up security fixes
+- Updated HMS image version dependencies
+- Updated k8s_api_checker.yaml from v3 to v4
 - Internal tracking ticket: CASMHMS-6599
 
 ## [6.1.4] - 2025-09-23

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v6.1.X will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.1.5] - 2025-09-26
+## [6.1.5] - 2025-09-25
 
 ### Security
 

--- a/changelog/v6.1.md
+++ b/changelog/v6.1.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Alpine base image to pick up security fixes
 - Updated HMS image version dependencies
 - Updated k8s_api_checker.yaml from v3 to v4
-- Internal tracking ticket: CASMHMS-6599
+- Internal tracking ticket: CASMHMS-6602
 
 ## [6.1.4] - 2025-09-23
 

--- a/charts/v6.1/cray-hms-sls/Chart.yaml
+++ b/charts/v6.1/cray-hms-sls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-sls"
-version: 6.1.4
+version: 6.1.5
 description: "Kubernetes resources for cray-hms-sls"
 home: https://github.com/Cray-HPE/hms-sls-charts
 sources:
@@ -14,9 +14,9 @@ dependencies:
   - name: cray-postgresql
     version: "~2.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-appVersion: 2.11.0  # update pprof image version below as well
+appVersion: 2.12.0  # update pprof image version below as well
 annotations:
   artifacthub.io/images: |-
     - name: cray-sls-pprof
-      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.11.0
+      image: artifactory.algol60.net/csm-docker/stable/cray-sls-pprof:2.12.0
   artifacthub.io/license: MIT

--- a/charts/v6.1/cray-hms-sls/values.yaml
+++ b/charts/v6.1/cray-hms-sls/values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
-  appVersion: 2.11.0
-  testVersion: 2.11.0
+  appVersion: 2.12.0
+  testVersion: 2.12.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-sls

--- a/cray-hms-sls.compatibility.yaml
+++ b/cray-hms-sls.compatibility.yaml
@@ -56,6 +56,7 @@ chartVersionToApplicationVersion:
   "6.1.2": "2.9.0"
   "6.1.3": "2.10.0"
   "6.1.4": "2.11.0"
+  "6.1.5": "2.12.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog:


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated all of the HMS image dependencies.

Also updated chart build usage of k8s_api_checker.yaml workflow from v3 to v4 because we were having build issues.

Adopted app version 2.12.0 for CSM 1.7.1 (helm chart 6.1.5)

### Issues and Related PRs

* Resolves [CASMHMS-6602](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6602)

### Testing

Tested via pipeline execution of CT tests and on system mug.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Release Notes in [docs-csm](https://github.com/Cray-HPE/docs-csm) updated, if applicable